### PR TITLE
Fix SVG namespace in close button

### DIFF
--- a/content.js
+++ b/content.js
@@ -48,7 +48,7 @@ function createCloseButton() {
     const closeButton = document.createElement('button');
     closeButton.setAttribute('aria-label', 'Close');
     closeButton.innerHTML = `
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="(link unavailable)">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M18 6L6 18" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M6 6L18 18" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>`;


### PR DESCRIPTION
## Summary
- correct the `xmlns` attribute for the close button SVG in `content.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff2942340832295e34d40c6e3dbb5