### PR TITLE
Add Jest tests for DOM utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/content.js
+++ b/content.js
@@ -209,5 +209,9 @@ function processTranscriptInChunks(transcriptText) {
     summarizeNextChunk();
 }
 
-injectButton();
-new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
+if (typeof module === 'undefined') {
+    injectButton();
+    new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
+} else {
+    module.exports = { createDynamicMessageContainer, toggleSummarySidePane };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "youtubesummarizer",
+  "version": "1.0.0",
+  "description": "![image](https://github.com/fbader927/youtubesummarizer/assets/50185837/68c33d87-8145-45a4-b129-5979e17eaf01)",
+  "main": "background.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jsdom": "^26.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,0 +1,27 @@
+const { createDynamicMessageContainer, toggleSummarySidePane } = require('../content');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('createDynamicMessageContainer', () => {
+  test('should create the container only once', () => {
+    const first = createDynamicMessageContainer();
+    const second = createDynamicMessageContainer();
+    expect(first).toBe(second);
+    expect(document.querySelectorAll('#dynamic-message').length).toBe(1);
+    expect(document.getElementById('summary-side-pane')).not.toBeNull();
+  });
+});
+
+describe('toggleSummarySidePane', () => {
+  test('should add a new .contentContainer and display the pane', () => {
+    toggleSummarySidePane('hello');
+    const sidePane = document.getElementById('summary-side-pane');
+    expect(sidePane).not.toBeNull();
+    expect(sidePane.style.display).toBe('block');
+    const containers = sidePane.querySelectorAll('.contentContainer');
+    expect(containers.length).toBe(1);
+    expect(containers[0].innerHTML).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- set up `package.json` with Jest and jsdom
- export functions from `content.js` for testing
- create `.gitignore`
- add tests for DOM side-pane utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683ff63d57408322935fb981ce5118d4