### PR TITLE
Fix Summarize button not loading consistently

### DIFF
--- a/content.js
+++ b/content.js
@@ -212,6 +212,7 @@ function processTranscriptInChunks(transcriptText) {
 if (typeof module === 'undefined') {
     injectButton();
     new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
+    window.addEventListener('yt-navigate-finish', () => setTimeout(injectButton, 1000));
 } else {
     module.exports = { createDynamicMessageContainer, toggleSummarySidePane };
 }


### PR DESCRIPTION
## Summary
- hook into YouTube navigation events so the Summarize button is reinjected after SPA page changes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684000efd4d083229ecade3999d237e4