### PR TITLE
UI and summarization fixes

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,7 +10,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         })
             .then(response => response.ok ? response.json() : Promise.reject('HTTP error, status = ' + response.status))
             .then(data => sendResponse({ success: true, data: decodeURIComponent(data.choices[0].message.content) }))
-            .catch(error => sendResponse({ success: false, error: error }));
+            .catch(error => {
+                const message = error && error.message ? error.message : String(error);
+                sendResponse({ success: false, error: message });
+            });
 
         return true;
     }

--- a/content.js
+++ b/content.js
@@ -1,4 +1,9 @@
 function injectButton() {
+    if (!location.href.includes('watch')) {
+        const existing = document.getElementById('askButton');
+        if (existing) existing.remove();
+        return;
+    }
     const moreActionsMenu = document.querySelector('ytd-menu-renderer yt-icon-button.dropdown-trigger');
     const descriptionBox = document.querySelector('ytd-video-secondary-info-renderer');
     const targetElement = moreActionsMenu || descriptionBox;
@@ -202,3 +207,15 @@ function processTranscriptInChunks(transcriptText) {
 
 injectButton();
 new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
+
+let lastUrl = location.href;
+setInterval(() => {
+    if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        injectButton();
+        if (!location.href.includes('watch')) {
+            const sidePane = document.getElementById('summary-side-pane');
+            if (sidePane) sidePane.style.display = 'none';
+        }
+    }
+}, 1000);

--- a/contentStyles.css
+++ b/contentStyles.css
@@ -50,23 +50,34 @@
     position: fixed;
     top: 56px;
     right: 20px;
-    width: 350px;
+    width: 380px;
     bottom: 56px;
-    background-color: #181818;
+    background-color: #1f1f1f;
     color: #FFF;
     border-left: 1px solid #303030;
-    padding: 16px;
-    box-shadow: -2px 0 6px rgba(0, 0, 0, 0.2);
+    padding: 20px;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.4);
     overflow-y: auto;
-    z-index: 1000;
+    z-index: 10000;
     font-size: 16px;
     font-family: 'Roboto', sans-serif;
     line-height: 1.6;
+    border-radius: 8px 0 0 8px;
     display: none;
 }
 
 .contentContainer {
-    margin-top: 40px;
+    margin-top: 20px;
+    background-color: #252525;
+    padding: 12px;
+    border-radius: 6px;
+    margin-bottom: 12px;
+}
+
+.dynamicMessage {
+    margin-bottom: 12px;
+    font-style: italic;
+    color: #ccc;
 }
 
 @keyframes rotate {


### PR DESCRIPTION
## Summary
- prevent summarizer button on non-video pages
- show clearer backend error messages
- hide summary pane when navigating away
- restyle summary pane for more professional look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff03387e483229af7ccb1b8c8da31