### PR TITLE
Fix stray Summarize buttons

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,4 +1,7 @@
 function injectButton() {
+    if (window.location.pathname !== '/watch') {
+        return;
+    }
     const moreActionsMenu = document.querySelector('ytd-menu-renderer yt-icon-button.dropdown-trigger');
     const descriptionBox = document.querySelector('ytd-video-secondary-info-renderer');
     const targetElement = moreActionsMenu || descriptionBox;


### PR DESCRIPTION
## Summary
- ensure Summarize button is only injected on watch pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684002a2e718832298032375cb3dd229