### PR TITLE
Improve summarizer error handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,7 +10,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         })
             .then(response => response.ok ? response.json() : Promise.reject('HTTP error, status = ' + response.status))
             .then(data => sendResponse({ success: true, data: decodeURIComponent(data.choices[0].message.content) }))
-            .catch(error => sendResponse({ success: false, error: error }));
+            .catch(error => {
+                const errorMessage = error && error.message ? error.message : String(error);
+                sendResponse({ success: false, error: errorMessage });
+            });
 
         return true;
     }

--- a/content.js
+++ b/content.js
@@ -199,9 +199,10 @@ function processTranscriptInChunks(transcriptText) {
         chrome.runtime.sendMessage({ action: 'summarize', text: chunk }, (response) => {
             if (!response.success) {
                 clearInterval(intervalId);
-                toggleSummarySidePane('Error in processing summary: ' + response.error);
+                const errorText = response.error || 'Unknown error';
+                toggleSummarySidePane('Error in processing summary: ' + errorText + '. Please reload and try again.');
                 hideLoadingIndicator();
-                isSummarizing = false;  
+                isSummarizing = false;
                 return;
             }
             toggleSummarySidePane(response.data, true);  


### PR DESCRIPTION
## Summary
- handle fetch errors from the summarizer by converting them to readable strings
- display a reload suggestion if summarization fails

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684005aa1d4083229ea463d92161a530