### PR TITLE
Fix summary pane persistence

### DIFF
--- a/content.js
+++ b/content.js
@@ -26,15 +26,18 @@ function injectButton() {
     }
 }
 
-window.addEventListener('unload', function () {
+function closeSummarySidePane() {
     const sidePane = document.getElementById('summary-side-pane');
     if (sidePane) {
-        sidePane.innerHTML = ''; 
+        sidePane.innerHTML = '';
+        sidePane.style.display = 'none';
     }
     clearInterval(intervalId);
-    isSummarizing = false; 
-    hideLoadingIndicator(); 
-});
+    isSummarizing = false;
+    hideLoadingIndicator();
+}
+
+window.addEventListener('unload', closeSummarySidePane);
 
 function showLoadingIndicator() {
     const loadingIndicator = document.querySelector('.loading-indicator');
@@ -216,7 +219,13 @@ function processTranscriptInChunks(transcriptText) {
 if (typeof module === 'undefined') {
     injectButton();
     new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
-    window.addEventListener('yt-navigate-finish', () => setTimeout(injectButton, 1000));
+    window.addEventListener('yt-navigate-start', closeSummarySidePane);
+    window.addEventListener('yt-navigate-finish', () => {
+        if (window.location.pathname !== '/watch') {
+            closeSummarySidePane();
+        }
+        setTimeout(injectButton, 1000);
+    });
 } else {
-    module.exports = { createDynamicMessageContainer, toggleSummarySidePane };
+    module.exports = { createDynamicMessageContainer, toggleSummarySidePane, closeSummarySidePane };
 }

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,4 +1,4 @@
-const { createDynamicMessageContainer, toggleSummarySidePane } = require('../content');
+const { createDynamicMessageContainer, toggleSummarySidePane, closeSummarySidePane } = require('../content');
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -23,5 +23,15 @@ describe('toggleSummarySidePane', () => {
     const containers = sidePane.querySelectorAll('.contentContainer');
     expect(containers.length).toBe(1);
     expect(containers[0].innerHTML).toBe('hello');
+  });
+});
+
+describe('closeSummarySidePane', () => {
+  test('should hide and clear the side pane', () => {
+    toggleSummarySidePane('hello');
+    closeSummarySidePane();
+    const sidePane = document.getElementById('summary-side-pane');
+    expect(sidePane.style.display).toBe('none');
+    expect(sidePane.innerHTML).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- hide and clear summary pane when navigating away from videos
- export `closeSummarySidePane` and add tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684007a06ec88322b08f3e2223fa85b5