### PR TITLE
Remove unused decoding to fix URI malformed errors

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,11 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === 'summarize' && request.text) {
-        const encodedText = encodeURIComponent(request.text);
-        const requestBody = JSON.stringify({ text: encodedText });
+        // The API expects plain text within the JSON payload, so avoid encoding
+        // the text here. Encoding led to mismatched handling on the backend
+        // which occasionally returned unencoded strings containing percent
+        // symbols (e.g. "100%"), causing `decodeURIComponent` to throw a
+        // "URI malformed" error when processing the response.
+        const requestBody = JSON.stringify({ text: request.text });
 
         fetch('https://summarizer-pcsze5jcyq-wl.a.run.app/api/summarize', {
             method: 'POST',
@@ -9,7 +13,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             body: requestBody
         })
             .then(response => response.ok ? response.json() : Promise.reject('HTTP error, status = ' + response.status))
-            .then(data => sendResponse({ success: true, data: decodeURIComponent(data.choices[0].message.content) }))
+            // The response content is plain text, so avoid decoding to prevent
+            // "URI malformed" errors when the text contains stray percent
+            // characters.
+            .then(data => sendResponse({ success: true, data: data.choices[0].message.content }))
             .catch(error => {
                 const errorMessage = error && error.message ? error.message : String(error);
                 sendResponse({ success: false, error: errorMessage });


### PR DESCRIPTION
## Summary
- avoid encoding request body and decoding response in `background.js`
- add comments explaining the reasoning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68400e1a75a48322a5632dd7766f0956