### PR TITLE
Fix side pane buttons disappearing

### DIFF
--- a/content.js
+++ b/content.js
@@ -29,7 +29,11 @@ function injectButton() {
 function closeSummarySidePane() {
     const sidePane = document.getElementById('summary-side-pane');
     if (sidePane) {
-        sidePane.innerHTML = '';
+        sidePane.querySelectorAll('.contentContainer').forEach(el => el.remove());
+        const loading = sidePane.querySelector('.pane-loading-indicator');
+        if (loading) loading.remove();
+        const dynamicMessage = document.getElementById('dynamic-message');
+        if (dynamicMessage) dynamicMessage.innerHTML = '';
         sidePane.style.display = 'none';
     }
     if (restoreButton) {

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -27,11 +27,13 @@ describe('toggleSummarySidePane', () => {
 });
 
 describe('closeSummarySidePane', () => {
-  test('should hide and clear the side pane', () => {
+  test('should hide the side pane and remove summary content only', () => {
     toggleSummarySidePane('hello');
     closeSummarySidePane();
     const sidePane = document.getElementById('summary-side-pane');
     expect(sidePane.style.display).toBe('none');
-    expect(sidePane.innerHTML).toBe('');
+    expect(sidePane.querySelector('.contentContainer')).toBeNull();
+    expect(document.getElementById('summary-close-button')).not.toBeNull();
+    expect(document.getElementById('summary-minimize-button')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- prevent removal of control buttons when closing summary pane
- update tests to reflect side pane behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684015ff8ef0832299ec82b176931ea0