### PR TITLE
Fix transcript caching issue

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,11 +235,22 @@ function clickShowTranscriptButton() {
 
 function fetchTranscriptFromCaptionsApi() {
     try {
-        const playerResponse = window.ytInitialPlayerResponse ||
-            JSON.parse([...document.querySelectorAll('script')]
+        let playerResponse = window.ytInitialPlayerResponse;
+
+        if (!playerResponse) {
+            const scripts = [...document.querySelectorAll('script')].reverse();
+            const scriptContent = scripts
                 .map(s => s.textContent)
-                .find(t => t.includes('ytInitialPlayerResponse'))
-                .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+                .find(t => t.includes('ytInitialPlayerResponse'));
+            if (!scriptContent) {
+                return Promise.reject('Transcript not available for this video.');
+            }
+            const match = scriptContent.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/);
+            if (!match) {
+                return Promise.reject('Transcript not available for this video.');
+            }
+            playerResponse = JSON.parse(match[1]);
+        }
 
         const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks;
         if (!tracks || !tracks.length) {

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -37,3 +37,26 @@ describe('closeSummarySidePane', () => {
     expect(document.getElementById('summary-minimize-button')).not.toBeNull();
   });
 });
+
+describe('fetchTranscriptFromCaptionsApi', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ events: [] }) }));
+    delete global.window.ytInitialPlayerResponse;
+  });
+
+  test('uses the most recent ytInitialPlayerResponse script', async () => {
+    const oldScript = document.createElement('script');
+    oldScript.textContent = 'var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"old","languageCode":"en"}]}}};';
+    document.body.appendChild(oldScript);
+
+    const newScript = document.createElement('script');
+    newScript.textContent = 'var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"new","languageCode":"en"}]}}};';
+    document.body.appendChild(newScript);
+
+    const { fetchTranscriptFromCaptionsApi } = require('../content');
+    await fetchTranscriptFromCaptionsApi();
+
+    expect(fetch).toHaveBeenCalledWith('new&fmt=json3');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure fetchTranscriptFromCaptionsApi reads the most recent ytInitialPlayerResponse
- test that the last ytInitialPlayerResponse script is used when fetching transcripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f8074fb483229f02c21e887283f7