### PR TITLE
Fix transcript caching across video navigation

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,11 +235,11 @@ function clickShowTranscriptButton() {
 
 function fetchTranscriptFromCaptionsApi() {
     try {
-        const playerResponse = window.ytInitialPlayerResponse ||
-            JSON.parse([...document.querySelectorAll('script')]
-                .map(s => s.textContent)
-                .find(t => t.includes('ytInitialPlayerResponse'))
-                .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+        const scripts = [...document.querySelectorAll('script')]
+            .map(s => s.textContent)
+            .filter(t => t.includes('ytInitialPlayerResponse'));
+        const playerResponse = JSON.parse(scripts.pop()
+            .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
 
         const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks;
         if (!tracks || !tracks.length) {

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,4 +1,4 @@
-const { createDynamicMessageContainer, toggleSummarySidePane, closeSummarySidePane } = require('../content');
+const { createDynamicMessageContainer, toggleSummarySidePane, closeSummarySidePane, fetchTranscriptFromCaptionsApi } = require('../content');
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -35,5 +35,18 @@ describe('closeSummarySidePane', () => {
     expect(sidePane.querySelector('.contentContainer')).toBeNull();
     expect(document.getElementById('summary-close-button')).not.toBeNull();
     expect(document.getElementById('summary-minimize-button')).not.toBeNull();
+  });
+});
+
+describe('fetchTranscriptFromCaptionsApi', () => {
+  test('uses the most recent ytInitialPlayerResponse script', async () => {
+    document.body.innerHTML = `
+      <script>var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"languageCode":"en","baseUrl":"https://old"}]}}};</script>
+      <script>var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"languageCode":"en","baseUrl":"https://new"}]}}};</script>
+    `;
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    await fetchTranscriptFromCaptionsApi();
+    expect(global.fetch).toHaveBeenCalledWith('https://new&fmt=json3');
+    delete global.fetch;
   });
 });


### PR DESCRIPTION
## Summary
- parse latest `ytInitialPlayerResponse` script to avoid old transcripts
- test that most recent player response is used

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411845e14c83228c378d075728ff12