### PR TITLE
Fix transcript fetch regression

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,11 +235,16 @@ function clickShowTranscriptButton() {
 
 function fetchTranscriptFromCaptionsApi() {
     try {
-        const scripts = [...document.querySelectorAll('script')]
-            .map(s => s.textContent)
-            .filter(t => t.includes('ytInitialPlayerResponse'));
-        const playerResponse = JSON.parse(scripts.pop()
-            .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+        let playerResponse = window.ytInitialPlayerResponse;
+        if (!playerResponse || !playerResponse.captions) {
+            const scripts = [...document.querySelectorAll('script')]
+                .map(s => s.textContent)
+                .filter(t => t.includes('ytInitialPlayerResponse'));
+            const lastScript = scripts.pop();
+            if (!lastScript) throw new Error('No player response script found');
+            playerResponse = JSON.parse(lastScript
+                .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+        }
 
         const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks;
         if (!tracks || !tracks.length) {

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -49,4 +49,22 @@ describe('fetchTranscriptFromCaptionsApi', () => {
     expect(global.fetch).toHaveBeenCalledWith('https://new&fmt=json3');
     delete global.fetch;
   });
+
+  test('prefers window.ytInitialPlayerResponse when available', async () => {
+    window.ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [{ languageCode: 'en', baseUrl: 'https://window' }]
+        }
+      }
+    };
+    document.body.innerHTML = `
+      <script>var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"languageCode":"en","baseUrl":"https://old"}]}}};</script>
+    `;
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    await fetchTranscriptFromCaptionsApi();
+    expect(global.fetch).toHaveBeenCalledWith('https://window&fmt=json3');
+    delete global.fetch;
+    delete window.ytInitialPlayerResponse;
+  });
 });


### PR DESCRIPTION
## Summary
- handle global `ytInitialPlayerResponse` again when fetching captions
- test that the global player response is preferred

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684119c9f2d883229bfa6cd7bbf2bb17