### PR TITLE
Fix transcript caching across video navigation

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,13 +235,22 @@ function clickShowTranscriptButton() {
 
 function fetchTranscriptFromCaptionsApi() {
     try {
-        const playerResponse = window.ytInitialPlayerResponse ||
-            JSON.parse([...document.querySelectorAll('script')]
-                .map(s => s.textContent)
-                .find(t => t.includes('ytInitialPlayerResponse'))
-                .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+        const scriptContents = Array.from(document.querySelectorAll('script'))
+            .map(s => s.textContent)
+            .filter(t => t.includes('ytInitialPlayerResponse'));
+        const latestScript = scriptContents[scriptContents.length - 1];
+        let playerResponse;
+        if (latestScript) {
+            const match = latestScript.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/);
+            if (match && match[1]) {
+                playerResponse = JSON.parse(match[1]);
+            }
+        }
+        if (!playerResponse) {
+            playerResponse = window.ytInitialPlayerResponse;
+        }
 
-        const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+        const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
         if (!tracks || !tracks.length) {
             return Promise.reject('Transcript not available for this video.');
         }


### PR DESCRIPTION
## Summary
- fetch transcript from the newest `ytInitialPlayerResponse` script rather than stale scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411c301ce8832293c09fa9d9d1f608