### PR TITLE
Fix transcript retrieval bug

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,11 +235,28 @@ function clickShowTranscriptButton() {
 
 function fetchTranscriptFromCaptionsApi() {
     try {
-        const playerResponse = window.ytInitialPlayerResponse ||
-            JSON.parse([...document.querySelectorAll('script')]
-                .map(s => s.textContent)
-                .find(t => t.includes('ytInitialPlayerResponse'))
-                .match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/)[1]);
+        let playerResponse;
+
+        const scriptContent = [...document.querySelectorAll('script')]
+            .map(s => s.textContent)
+            .find(t => t.includes('ytInitialPlayerResponse'));
+
+        if (scriptContent) {
+            const match = scriptContent.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/);
+            if (match && match[1]) {
+                playerResponse = JSON.parse(match[1]);
+                // ensure global is updated for subsequent reads
+                window.ytInitialPlayerResponse = playerResponse;
+            }
+        }
+
+        if (!playerResponse) {
+            playerResponse = window.ytInitialPlayerResponse;
+        }
+
+        if (!playerResponse) {
+            return Promise.reject('Transcript not available for this video.');
+        }
 
         const tracks = playerResponse.captions?.playerCaptionsTracklistRenderer?.captionTracks;
         if (!tracks || !tracks.length) {


### PR DESCRIPTION
## Summary
- keep `window.ytInitialPlayerResponse` updated by always parsing the script tag
- fall back to `window.ytInitialPlayerResponse` only if needed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684120c3ec3c83228a665ebd81fc9432