### PR TITLE
Fix transcript persistence across videos

### DIFF
--- a/content.js
+++ b/content.js
@@ -252,8 +252,10 @@ function fetchTranscriptFromCaptionsApi() {
     try {
         let playerResponse;
 
-        const scriptContent = [...document.querySelectorAll('script')]
+        const scripts = Array.from(document.querySelectorAll('script'));
+        const scriptContent = scripts
             .map(s => s.textContent)
+            .reverse()
             .find(t => t.includes('ytInitialPlayerResponse'));
 
         if (scriptContent) {
@@ -385,8 +387,11 @@ function processTranscriptInChunks(transcriptText) {
 if (typeof module === 'undefined') {
     injectButton();
     new MutationObserver(injectButton).observe(document.body, { childList: true, subtree: true });
-    window.addEventListener('yt-navigate-start', () => {
+    function resetPlayerResponse() {
         delete window.ytInitialPlayerResponse;
+    }
+    window.addEventListener('yt-navigate-start', () => {
+        resetPlayerResponse();
         closeSummarySidePane();
     });
     window.addEventListener('yt-navigate-finish', () => {
@@ -395,6 +400,7 @@ if (typeof module === 'undefined') {
         }
         setTimeout(injectButton, 1000);
     });
+    window.addEventListener('yt-page-data-updated', resetPlayerResponse);
 } else {
     module.exports = {
         createDynamicMessageContainer,


### PR DESCRIPTION
## Summary
- ensure we parse the latest `ytInitialPlayerResponse` script when fetching transcripts
- clear stored player response when navigating to a new video
- add `yt-page-data-updated` listener for better cleanup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68412c266308832287531ddac6ee2575